### PR TITLE
New facet grouping algorithm

### DIFF
--- a/lsmtool/operations/group.py
+++ b/lsmtool/operations/group.py
@@ -101,8 +101,9 @@ def group(LSM, algorithm, targetFlux=None, numClusters=100, FWHM=None,
         - 'mean' => the positions is set to the mean RA and Dec of the patch
         - 'wmean' => the position is set to the flux-weighted mean RA and
         Dec of the patch
+        - 'zero' => set all positions to [0.0, 0.0]
     facet : str, optional
-        Facet fits file used with the algorithm 'facet'    - 'zero' => set all positions to [0.0, 0.0]
+        Facet fits file used with the algorithm 'facet'
 
     Examples
     --------

--- a/lsmtool/operations/group.py
+++ b/lsmtool/operations/group.py
@@ -50,7 +50,7 @@ def run(step, parset, LSM):
 
 
 def group(LSM, algorithm, targetFlux=None, numClusters=100, FWHM=None,
-    threshold=0.1, applyBeam=False, root='Patch', method='mid'):
+    threshold=0.1, applyBeam=False, root='Patch', method='mid', facet=""):
     """
     Groups sources into patches.
 
@@ -69,6 +69,9 @@ def group(LSM, algorithm, targetFlux=None, numClusters=100, FWHM=None,
         - 'threshold' => group by convolving the sky model with a Gaussian beam
             and then thresholding to find islands of emission (NOTE: all sources
             are currently considered to be point sources of flux unity)
+        - 'facet' => group by facets using as an input a fits file. It requires
+            the use of the additional parameter 'facet' to enter the name of the 
+            fits file (NOTE: This method is experimental).
         - the filename of a mask image => group by masked regions (where mask =
             True). Source outside of masked regions are given patches of their
             own
@@ -98,7 +101,8 @@ def group(LSM, algorithm, targetFlux=None, numClusters=100, FWHM=None,
         - 'mean' => the positions is set to the mean RA and Dec of the patch
         - 'wmean' => the position is set to the flux-weighted mean RA and
         Dec of the patch
-        - 'zero' => set all positions to [0.0, 0.0]
+    facet : str, optional
+        Facet fits file used with the algorithm 'facet'    - 'zero' => set all positions to [0.0, 0.0]
 
     Examples
     --------
@@ -185,6 +189,15 @@ def group(LSM, algorithm, targetFlux=None, numClusters=100, FWHM=None,
             root=root)
         LSM.setColValues('Patch', patchCol, index=2)
 
+    elif algorithm.lower() == 'facet':
+        if os.path.exists(facet):
+            RARad = LSM.getColValues('Ra', units='degree')
+            DecRad = LSM.getColValues('Dec', units='degree')
+            facet_col = get_facet_values(facet, RARad, DecRad, root=root)
+            LSM.setColValues('Patch', facet_col, index=2)
+        else:
+            raise ValueError('Please enter the facet filename in the facet parameter.')
+
     elif os.path.exists(algorithm):
         # Mask image
         mask = algorithm
@@ -268,3 +281,42 @@ def getPatchNamesFromMask(mask, RARad, DecRad, root='mask'):
             n += 1
 
     return np.array(patchNames)
+
+def get_facet_values(facet, ra, dec, root="facet", default=0):
+    """
+    Extract the value from a fits facet file 
+    """
+    import numpy as np
+    from astropy.io import fits
+    from astropy.wcs import WCS
+    
+    # TODO: Check astropy version
+    # TODO: Check facet is a fits file
+
+    with fits.open(facet) as f:
+        shape = f[0].data.shape
+        
+        w = WCS(f[0].header)
+        freq = w.wcs.crval[2]
+        stokes = w.wcs.crval[3]
+        
+        xe, ye, _1, _2 = w.all_world2pix(ra, dec, freq, stokes, 1)
+        x, y = np.round(xe).astype(int), np.round(ye).astype(int)
+        
+        # Dummy value for points out of the fits area
+        x[(x < 0) | (x >= shape[-1])] = -1
+        y[(y < 0) | (y >= shape[-2])] = -1
+
+        data = f[0].data[0,0,:,:]
+        
+        values = data[y, x]
+        
+        # Assign the default value to NaNs and points out of the fits area
+        values[(x == -1) | (y == -1)] = default
+        values[np.isnan(values)] = default
+        
+        #TODO: Flexible format for other data types ?
+        return np.array(["{}_{:.0f}".format(root, val) for val in values])
+        
+                
+    

--- a/lsmtool/skymodel.py
+++ b/lsmtool/skymodel.py
@@ -1954,7 +1954,7 @@ class SkyModel(object):
 
 
     def group(self, algorithm, targetFlux=None, numClusters=100, FWHM=None,
-        threshold=0.1, applyBeam=False, root='Patch', method='mid'):
+        threshold=0.1, applyBeam=False, root='Patch', method='mid', facet=""):
         """
         Groups sources into patches.
 
@@ -1973,6 +1973,9 @@ class SkyModel(object):
             - 'threshold' => group by convolving the sky model with a Gaussian beam
                 and then thresholding to find islands of emission (NOTE: all sources
                 are currently considered to be point sources of flux unity)
+            - 'facet' => group by facets using as an input a fits file. It requires
+                the use of the additional parameter 'facet' to enter the name of the 
+                fits file (NOTE: This method is experimental).
             - the filename of a mask image => group by masked regions (where mask =
                 True). Source outside of masked regions are given patches of their
                 own.
@@ -2003,6 +2006,8 @@ class SkyModel(object):
             - 'wmean' => the position is set to the flux-weighted mean RA and
             Dec of the patch
             - 'zero' => set all positions to [0.0, 0.0]
+        facet : str, optional
+            Facet fits file used with the algorithm 'facet'
 
         Examples
         --------
@@ -2014,7 +2019,7 @@ class SkyModel(object):
         """
         operations.group.group(self, algorithm, targetFlux=targetFlux,
             numClusters=numClusters, FWHM=FWHM, threshold=threshold,
-            applyBeam=applyBeam, root=root, method=method)
+            applyBeam=applyBeam, root=root, method=method, facet=facet)
 
 
     def transfer(self, patchSkyModel, matchBy='name', radius=0.1):


### PR DESCRIPTION
It should be similar to the specification of a mask filename but it does not require pyrap and I could make it work with the mask files generated by the facet generation routine of Reinout's pipeline.

It should not break backwards compatibility unless there was a mask file called "facet". It can be improved in the future to cover more user cases. At the moment, for example, it sets a value of "Facet_0" by default to the points out of the mask.