### PR TITLE
Adapt to Python 3

### DIFF
--- a/lsmtool/__init__.py
+++ b/lsmtool/__init__.py
@@ -24,7 +24,7 @@ SkyModel object.
 """
 
 from ._version import changelog
-import _logging as logger
+from . import _logging as logger
 logger.setLevel('info')
 
 

--- a/lsmtool/operations/__init__.py
+++ b/lsmtool/operations/__init__.py
@@ -1,5 +1,9 @@
-import os
-import glob
+from os.path import dirname, basename, isfile
+from glob import glob
 
-__all__ = [ os.path.basename(f)[:-3] for f in glob.glob(os.path.dirname(__file__)+"/*.py") if not f.endswith('__init__.py') and not f.split('/')[-1].startswith('_')]
-for x in __all__: __import__(x, locals(), globals())
+modules = glob(dirname(__file__)+"/*.py")
+__all__ = [basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py') and not basename(f).startswith('_')]
+del modules
+
+from . import *
+

--- a/lsmtool/operations/_filter.py
+++ b/lsmtool/operations/_filter.py
@@ -18,6 +18,20 @@
 
 import logging
 log = logging.getLogger('LSMTool.Filter')
+try:
+    dict.iteritems
+except AttributeError:
+    # Python 3
+    def itervalues(d):
+        return iter(d.values())
+    def iteritems(d):
+        return iter(d.items())
+else:
+    # Python 2
+    def itervalues(d):
+        return d.itervalues()
+    def iteritems(d):
+        return d.iteritems()
 
 
 def filter(LSM, filterExpression, exclusive=False, aggregate=None,
@@ -391,7 +405,7 @@ def convertOperStr(operStr):
                     # Pick longer match
                     filterOperStr = op
     else:
-        for k, v in ops.iteritems():
+        for k, v in iteritems(ops):
             if v == operStr:
                 filterOperStr = k
     if filterOperStr is None:

--- a/lsmtool/operations/_tessellate.py
+++ b/lsmtool/operations/_tessellate.py
@@ -14,6 +14,7 @@
 # the file. All other rights are reserved.
 
 
+from __future__ import print_function
 import numpy as np
 from numpy import sum, sqrt, min, max, any
 from numpy import argmax, argmin, mean, abs
@@ -173,7 +174,8 @@ class bin2D:
         for ind in range(1,self.npix+1):  ## Running over the index of the Voronoi BIN
             ## Only one pixel at this stage
             current_flux = sum(self.data[currentBin])
-            if verbose : print "Bin %d"%(ind)
+            if verbose : 
+                print("Bin %d"%(ind)) # TODO: Change to logging
 
             self.status[currentBin] = ind   # only one pixel at this stage
             ## Barycentric centroid for 1 pixel...
@@ -309,7 +311,7 @@ class bin2D:
             minind = argmin(dist2(self.xin[i], self.yin[i], self.xnode, self.ynode, scale=self.scale))
             self.status[i] = self.statusnode[minind]
             if verbose :
-                print "Pixel ",  self.status[i], self.xin[i], self.yin[i], self.xnode[minind], self.ynode[minind]
+                print("Pixel ",  self.status[i], self.xin[i], self.yin[i], self.xnode[minind], self.ynode[minind]) # TODO: Change to logging
 
         ## reDerive the centroid
         self.bin2d_centroid()

--- a/lsmtool/operations/compare.py
+++ b/lsmtool/operations/compare.py
@@ -403,6 +403,7 @@ def plotFluxRatioSky(predFlux, measFlux, x, y, RA, Dec, midRA, midDec, labels,
         if matplotlib.get_backend() is not 'Agg':
             matplotlib.use("Agg")
         import matplotlib.pyplot as plt
+        import matplotlib.colors as colors
         from matplotlib.ticker import FuncFormatter
     except Exception as e:
         raise ImportError('PyPlot could not be imported. Plotting is not '
@@ -428,7 +429,7 @@ def plotFluxRatioSky(predFlux, measFlux, x, y, RA, Dec, midRA, midDec, labels,
     vmin = np.min(ratio) - 0.1
     vmax = np.max(ratio) + 0.1
     sm = plt.cm.ScalarMappable(cmap=plt.cm.jet,
-        norm=plt.normalize(vmin=vmin, vmax=vmax))
+        norm=colors.Normalize(vmin=vmin, vmax=vmax))
     sm.set_array(ratio)
     sm._A = []
     c = []

--- a/lsmtool/skymodel.py
+++ b/lsmtool/skymodel.py
@@ -21,6 +21,21 @@ from . import _logging
 from . import tableio
 from . import operations
 
+try:
+    dict.iteritems
+except AttributeError:
+    # Python 3
+    def itervalues(d):
+        return iter(d.values())
+    def iteritems(d):
+        return iter(d.items())
+else:
+    # Python 2
+    def itervalues(d):
+        return d.itervalues()
+    def iteritems(d):
+        return d.iteritems()
+
 
 class SkyModel(object):
     """
@@ -591,7 +606,7 @@ class SkyModel(object):
                     patchDict = self.getPatchPositions(method=method, applyBeam=
                         applyBeam, perPatchProjection=perPatchProjection)
 
-            for patch, pos in patchDict.iteritems():
+            for patch, pos in iteritems(patchDict):
                 if type(pos[0]) is str or type(pos[0]) is float:
                     pos[0] = RA2Angle(pos[0])
                 if type(pos[1]) is str or type(pos[1]) is float:
@@ -692,7 +707,7 @@ class SkyModel(object):
             >>> s.setDefaultValues({'ReferenceFrequency': 140e6})
 
         """
-        for colName, default in colDict.iteritems():
+        for colName, default in iteritems(colDict):
             self.table.meta[colName] = default
 
 
@@ -880,7 +895,7 @@ class SkyModel(object):
             else:
                 data = [0] * len(self.table)
                 mask = [True] * len(self.table)
-            for sourceName, value in values.iteritems():
+            for sourceName, value in iteritems(values):
                 indx = self._getNameIndx(sourceName)
                 if colName == 'Ra':
                     val = RA2Angle(value)[0]

--- a/lsmtool/skymodel.py
+++ b/lsmtool/skymodel.py
@@ -17,9 +17,9 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import logging
-import _logging
-import tableio
-import operations
+from . import _logging
+from . import tableio
+from . import operations
 
 
 class SkyModel(object):
@@ -72,7 +72,7 @@ class SkyModel(object):
 
         """
         from astropy.table import Table, Column
-        from tableio import requiredColumnNames, processFormatString, processLine, createTable
+        from .tableio import requiredColumnNames, processFormatString, processLine, createTable
 
         self.log = logging.getLogger('LSMTool')
         self.history = []
@@ -436,9 +436,9 @@ class SkyModel(object):
 
         """
         import numpy as np
-        from operations_lib import radec2xy, xy2radec
+        from .operations_lib import radec2xy, xy2radec
         from astropy.table import Column
-        from tableio import RA2Angle, Dec2Angle
+        from .tableio import RA2Angle, Dec2Angle
 
         if self.hasPatches:
             if patchName is None:
@@ -571,7 +571,7 @@ class SkyModel(object):
             >>> s.setPatchPositions({'bin0': [123.231, 23.4321]})
 
         """
-        from tableio import RA2Angle, Dec2Angle
+        from .tableio import RA2Angle, Dec2Angle
 
         if self.hasPatches:
             if method not in ['mid', 'mean', 'wmean', 'zero']:
@@ -620,7 +620,7 @@ class SkyModel(object):
             Dec values
 
         """
-        from operations_lib import radec2xy, xy2radec
+        from .operations_lib import radec2xy, xy2radec
         import numpy as np
 
         if len(self.table) == 0:
@@ -861,7 +861,7 @@ class SkyModel(object):
 
         """
         from astropy.table import Column
-        from tableio import RA2Angle, Dec2Angle
+        from .tableio import RA2Angle, Dec2Angle
         import numpy as np
 
         colName = self._verifyColName(colName, onlyExisting=False)
@@ -1251,7 +1251,7 @@ class SkyModel(object):
             Column object with flux values attenuated by the beam
 
         """
-        from operations_lib import attenuate
+        from .operations_lib import attenuate
 
         if not self._hasBeam:
             self.log.warn('No beam MS has been specified. No beam attenuation applied.')
@@ -1539,7 +1539,7 @@ class SkyModel(object):
             Angular separation in degrees
 
         """
-        from operations_lib import calculateSeparation
+        from .operations_lib import calculateSeparation
 
         return calculateSeparation(ra1, dec1, ra2, dec2)
 
@@ -1582,7 +1582,7 @@ class SkyModel(object):
             >>> s.getDistance(94.0, 42.0, byPatch=True)
 
         """
-        from tableio import RA2Angle, Dec2Angle
+        from .tableio import RA2Angle, Dec2Angle
 
         if byPatch and self.hasPatches:
             # Get patch positions

--- a/lsmtool/skymodel.py
+++ b/lsmtool/skymodel.py
@@ -21,6 +21,7 @@ from . import _logging
 from . import tableio
 from . import operations
 
+# Python 3 compatibility
 try:
     dict.iteritems
 except AttributeError:
@@ -29,13 +30,14 @@ except AttributeError:
         return iter(d.values())
     def iteritems(d):
         return iter(d.items())
+    numpy_type = "U"
 else:
     # Python 2
     def itervalues(d):
         return d.itervalues()
     def iteritems(d):
         return d.iteritems()
-
+    numpy_type = "S"
 
 class SkyModel(object):
     """
@@ -926,7 +928,7 @@ class SkyModel(object):
         else:
             if colName == 'Patch':
                 # Specify length of 50 characters
-                newCol = Column(name=colName, data=data, dtype='S50')
+                newCol = Column(name=colName, data=data, dtype='{}50'.format(numpy_type))
             else:
                 newCol = Column(name=colName, data=data)
             self.table.add_column(newCol, index=index)

--- a/lsmtool/tableio.py
+++ b/lsmtool/tableio.py
@@ -28,6 +28,24 @@ import re
 import logging
 import os
 
+# Python 3 compatibility
+try:
+    dict.iteritems
+except AttributeError:
+    # Python 3
+    def itervalues(d):
+        return iter(d.values())
+    def iteritems(d):
+        return iter(d.items())
+    numpy_type = "U"
+else:
+    # Python 2
+    def itervalues(d):
+        return d.itervalues()
+    def iteritems(d):
+        return d.iteritems()
+    numpy_type = "S"
+    
 
 # Define the valid columns here as dictionaries. The entry key is the lower-case
 # name of the column, the entry value is the key used in the astropy table of the
@@ -150,12 +168,12 @@ def createTable(outlines, metaDict, colNames, colDefaults):
 
     converters = {}
     nameCol = 'col{0}'.format(colNames.index('Name')+1)
-    converters[nameCol] = [ascii.convert_numpy('S100')]
+    converters[nameCol] = [ascii.convert_numpy('{}100'.format(numpy_type))]
     typeCol = 'col{0}'.format(colNames.index('Type')+1)
-    converters[typeCol] = [ascii.convert_numpy('S100')]
+    converters[typeCol] = [ascii.convert_numpy('{}100'.format(numpy_type))]
     if 'Patch' in colNames:
         patchCol = 'col{0}'.format(colNames.index('Patch')+1)
-        converters[patchCol] = [ascii.convert_numpy('S100')]
+        converters[patchCol] = [ascii.convert_numpy('{}100'.format(numpy_type))]
 
     log.debug('Creating table...')
     table = Table.read('\n'.join(outlines), guess=False, format='ascii.no_header', delimiter=',',
@@ -985,7 +1003,7 @@ def coneSearch(VOService, position, radius):
 
     # Make sure Name is a str column
     NameRaw = table['Name'].data.tolist()
-    NameCol = Column(name='Name', data=NameRaw, dtype='S100')
+    NameCol = Column(name='Name', data=NameRaw, dtype='{}100'.format(numpy_type))
     table.remove_column('Name')
     table.add_column(NameCol, index=0)
 
@@ -1005,7 +1023,7 @@ def coneSearch(VOService, position, radius):
         for i, maj in enumerate(table[allowedColumnNames['majoraxis']]):
             if maj > 0.0:
                 types[i] = 'GAUSSIAN'
-    col = Column(name='Type', data=types, dtype='S100')
+    col = Column(name='Type', data=types, dtype='{}100'.format(numpy_type))
     table.add_column(col, index=1)
 
     # Add reference-frequency column
@@ -1089,9 +1107,9 @@ def makeEmptyTable():
     colNames = ['Name', 'Type', 'Ra', 'Dec', 'I']
     converters = {}
     nameCol = 'col{0}'.format(colNames.index('Name')+1)
-    converters[nameCol] = [ascii.convert_numpy('S100')]
+    converters[nameCol] = [ascii.convert_numpy('{}100'.format(numpy_type))]
     typeCol = 'col{0}'.format(colNames.index('Type')+1)
-    converters[typeCol] = [ascii.convert_numpy('S100')]
+    converters[typeCol] = [ascii.convert_numpy('{}100'.format(numpy_type))]
     table = Table.read(outlines, guess=False, format='ascii.no_header', delimiter=',',
         names=colNames, comment='#', data_start=0, converters=converters)
     table.remove_rows(0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27,py34,py35,py36
+[testenv]
+commands = py.test
+deps =
+    numpy
+    astropy
+    scipy
+    matplotlib
+    pytest


### PR DESCRIPTION
The changes proposed would adapt LSMTool to work in Python 3. All the tests are passing in Python 2.7, 3.4, 3.5, and 3.6. 
Apart from the changes in the imports the main change is the use of Unicode strings in numpy. As this is an internal representation of the data I do not expect to cause incompatibilities with previous versions but I am not completely sure about this.
This will also solve issue #4.