### PR TITLE
Allow astropy >=4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,8 @@ else:
 if sys.version_info < (3, 0):
     reqlist = ['numpy', 'astropy >= 0.4, <3.0']
 else:
-    # Require astropy v3.2 or later to get much faster copies (4.x can cause some
-    # installation problems, so exclude for now)
-    reqlist = ['numpy', 'astropy >= 3.2, <4.0']
+    # Require astropy v3.2 or later to get much faster copies
+    reqlist = ['numpy', 'astropy >= 3.2']
 if build_c_extentions:
     reqlist.append('pybind11>=2.2.0')
     ext_modules = [Extension('lsmtool.operations._grouper',


### PR DESCRIPTION
The comment "4.x can cause some installation problems, so exclude for now)" was not very specific and astropy >= 4.0 is becoming more common. I suggest we allow this and solve the possible installation problems later.

Resolves #22